### PR TITLE
Throw when no history is found when useLink callback is called

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "semi": false,
+  "bracketSpacing": true
+}

--- a/browser/package.json
+++ b/browser/package.json
@@ -23,7 +23,7 @@
     "bundle": "microbundle --jsx React.createElement"
   },
   "name": "@reroute/browser",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "module": "dist/mod.mjs",
   "main": "dist/mod.js",
   "umd:main": "dist/foo.umd.js",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reroute/core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "source": "src/mod.js",
   "main": "dist/mod.js",
   "module": "dist/mod.mjs",

--- a/core/src/__tests__/mod.spec.js
+++ b/core/src/__tests__/mod.spec.js
@@ -1,159 +1,159 @@
-import React from "react";
-import { render, cleanup } from "react-testing-library";
+import React from 'react'
+import { render, cleanup } from 'react-testing-library'
 
-import { useHistory, useLink, useRoute, Router } from "../mod.js";
-import { createMemoryHistory } from "history";
+import { useHistory, useLink, useRoute, Router } from '../mod.js'
+import { createMemoryHistory } from 'history'
 
-afterEach(cleanup);
+afterEach(cleanup)
 
-test("it gives you the history", () => {
-  let hist;
+test('it gives you the history', () => {
+  let hist
   function Foo() {
-    hist = useHistory();
-    return null;
+    hist = useHistory()
+    return null
   }
 
   render(
     <Router createHistory={createMemoryHistory}>
       <Foo />
-    </Router>
-  );
+    </Router>,
+  )
 
-  expect(hist.location.pathname).toEqual("/");
-});
+  expect(hist.location.pathname).toEqual('/')
+})
 
-test("useLink provides a function to get link props", () => {
-  let func;
+test('useLink provides a function to get link props', () => {
+  let func
   function Foo() {
-    func = useLink("/path");
-    return null;
+    func = useLink('/path')
+    return null
   }
   render(
     <Router createHistory={createMemoryHistory}>
       <Foo />
-    </Router>
-  );
-  expect(typeof func).toBe("function");
-});
+    </Router>,
+  )
+  expect(typeof func).toBe('function')
+})
 
-test("calling the result of useLink provides the correct role", () => {
+test('calling the result of useLink provides the correct role', () => {
   function Foo() {
-    let getLinkProps = useLink("/foo");
+    let getLinkProps = useLink('/foo')
 
     return (
       <div {...getLinkProps()} data-testid="link">
         Yo
       </div>
-    );
+    )
   }
 
   let { queryByTestId } = render(
     <Router createHistory={createMemoryHistory}>
       <Foo />
-    </Router>
-  );
+    </Router>,
+  )
 
-  expect(queryByTestId("link").getAttribute("role")).toEqual("anchor");
-});
+  expect(queryByTestId('link').getAttribute('role')).toEqual('anchor')
+})
 
-test("useLink supports disabled links", () => {
+test('useLink supports disabled links', () => {
   function Foo() {
-    let getLinkProps = useLink("/foo");
+    let getLinkProps = useLink('/foo')
 
     return (
       <div {...getLinkProps({ disabled: true })} data-testid="link">
         Yo
       </div>
-    );
+    )
   }
 
   let { queryByTestId } = render(
     <Router createHistory={createMemoryHistory}>
       <Foo />
-    </Router>
-  );
+    </Router>,
+  )
 
-  expect(queryByTestId("link").getAttribute("role")).toEqual("presentation");
-});
+  expect(queryByTestId('link').getAttribute('role')).toEqual('presentation')
+})
 
-test("useRoute determines if it matches the provided path", () => {
-  let match;
+test('useRoute determines if it matches the provided path', () => {
+  let match
   function Foo() {
-    let { match: _match } = useRoute("/");
-    match = _match;
+    let { match: _match } = useRoute('/')
+    match = _match
 
-    return null;
+    return null
   }
 
   render(
     <Router createHistory={createMemoryHistory}>
       <Foo />
-    </Router>
-  );
+    </Router>,
+  )
 
-  expect(match).toBe(true);
-});
+  expect(match).toBe(true)
+})
 
-test("useRoute does not match for a different route", () => {
-  let match;
+test('useRoute does not match for a different route', () => {
+  let match
   function Foo() {
-    let { match: _match } = useRoute("/some-path-here");
+    let { match: _match } = useRoute('/some-path-here')
 
-    match = _match;
+    match = _match
 
-    return null;
+    return null
   }
   render(
     <Router createHistory={createMemoryHistory}>
       <Foo />
-    </Router>
-  );
+    </Router>,
+  )
 
-  expect(match).toBe(false);
-});
+  expect(match).toBe(false)
+})
 
 // Workaround react bug, see: https://github.com/facebook/react/issues/12485
 const pauseErrorLogging = codeToRun => {
-  const logger = console.error;
-  console.error = () => {};
+  const logger = console.error
+  console.error = () => {}
 
-  codeToRun();
+  codeToRun()
 
-  console.error = logger;
-};
+  console.error = logger
+}
 
-test("Router throws when no createHistory is provided, or its not a function", () => {
+test('Router throws when no createHistory is provided, or its not a function', () => {
   pauseErrorLogging(() =>
     expect(() => {
-      render(<Router />);
+      render(<Router />)
     }).toThrowErrorMatchingInlineSnapshot(
-      `"createHistory prop was either not provided, or is not a function."`
-    )
-  );
+      `"createHistory prop was either not provided, or is not a function."`,
+    ),
+  )
 
   pauseErrorLogging(() =>
     expect(() => {
-      render(<Router createHistory={null} />);
+      render(<Router createHistory={null} />)
     }).toThrowErrorMatchingInlineSnapshot(
-      `"createHistory prop was either not provided, or is not a function."`
-    )
-  );
-});
+      `"createHistory prop was either not provided, or is not a function."`,
+    ),
+  )
+})
 
-test("useLink`s linkClick callback throws when no history is provided within context", () => {
-  let clickHandler;
+test('useLink`s linkClick callback throws when no history is provided within context', () => {
+  let clickHandler
   function Link() {
-    let getLinkProps = useLink("/foo");
-    let { onClick, ...rest } = getLinkProps();
-    clickHandler = onClick;
-    return null;
+    let getLinkProps = useLink('/foo')
+    let { onClick, ...rest } = getLinkProps()
+    clickHandler = onClick
+    return null
   }
-  render(<Link />);
+  render(<Link />)
 
   expect(() => clickHandler({ defaultPrevented: false, preventDefault() {} }))
     .toThrowErrorMatchingInlineSnapshot(`
 "Link attempted to route to path: '/foo' but no history was found in context.
 
 Check to ensure the link is rendered within a Router."
-`);
-});
+`)
+})

--- a/core/src/__tests__/mod.spec.js
+++ b/core/src/__tests__/mod.spec.js
@@ -1,141 +1,159 @@
-import React from 'react'
-import { render, cleanup } from 'react-testing-library'
+import React from "react";
+import { render, cleanup } from "react-testing-library";
 
-import { useHistory, useLink, useRoute, Router } from '../mod.js'
-import { createMemoryHistory } from 'history'
+import { useHistory, useLink, useRoute, Router } from "../mod.js";
+import { createMemoryHistory } from "history";
 
-afterEach(cleanup)
+afterEach(cleanup);
 
-test('it gives you the history', () => {
-  let hist
+test("it gives you the history", () => {
+  let hist;
   function Foo() {
-    hist = useHistory()
-    return null
+    hist = useHistory();
+    return null;
   }
 
   render(
     <Router createHistory={createMemoryHistory}>
       <Foo />
-    </Router>,
-  )
+    </Router>
+  );
 
-  expect(hist.location.pathname).toEqual('/')
-})
+  expect(hist.location.pathname).toEqual("/");
+});
 
-test('useLink provides a function to get link props', () => {
-  let func
+test("useLink provides a function to get link props", () => {
+  let func;
   function Foo() {
-    func = useLink('/path')
-    return null
+    func = useLink("/path");
+    return null;
   }
   render(
     <Router createHistory={createMemoryHistory}>
       <Foo />
-    </Router>,
-  )
-  expect(typeof func).toBe('function')
-})
+    </Router>
+  );
+  expect(typeof func).toBe("function");
+});
 
-test('calling the result of useLink provides the correct role', () => {
+test("calling the result of useLink provides the correct role", () => {
   function Foo() {
-    let getLinkProps = useLink('/foo')
+    let getLinkProps = useLink("/foo");
 
     return (
       <div {...getLinkProps()} data-testid="link">
         Yo
       </div>
-    )
+    );
   }
 
   let { queryByTestId } = render(
     <Router createHistory={createMemoryHistory}>
       <Foo />
-    </Router>,
-  )
+    </Router>
+  );
 
-  expect(queryByTestId('link').getAttribute('role')).toEqual('anchor')
-})
+  expect(queryByTestId("link").getAttribute("role")).toEqual("anchor");
+});
 
-test('useLink supports disabled links', () => {
+test("useLink supports disabled links", () => {
   function Foo() {
-    let getLinkProps = useLink('/foo')
+    let getLinkProps = useLink("/foo");
 
     return (
       <div {...getLinkProps({ disabled: true })} data-testid="link">
         Yo
       </div>
-    )
+    );
   }
 
   let { queryByTestId } = render(
     <Router createHistory={createMemoryHistory}>
       <Foo />
-    </Router>,
-  )
+    </Router>
+  );
 
-  expect(queryByTestId('link').getAttribute('role')).toEqual('presentation')
-})
+  expect(queryByTestId("link").getAttribute("role")).toEqual("presentation");
+});
 
-test('useRoute determines if it matches the provided path', () => {
-  let match
+test("useRoute determines if it matches the provided path", () => {
+  let match;
   function Foo() {
-    let { match: _match } = useRoute('/')
-    match = _match
+    let { match: _match } = useRoute("/");
+    match = _match;
 
-    return null
+    return null;
   }
 
   render(
     <Router createHistory={createMemoryHistory}>
       <Foo />
-    </Router>,
-  )
+    </Router>
+  );
 
-  expect(match).toBe(true)
-})
+  expect(match).toBe(true);
+});
 
-test('useRoute does not match for a different route', () => {
-  let match
+test("useRoute does not match for a different route", () => {
+  let match;
   function Foo() {
-    let { match: _match } = useRoute('/some-path-here')
+    let { match: _match } = useRoute("/some-path-here");
 
-    match = _match
+    match = _match;
 
-    return null
+    return null;
   }
   render(
     <Router createHistory={createMemoryHistory}>
       <Foo />
-    </Router>,
-  )
+    </Router>
+  );
 
-  expect(match).toBe(false)
-})
+  expect(match).toBe(false);
+});
 
 // Workaround react bug, see: https://github.com/facebook/react/issues/12485
 const pauseErrorLogging = codeToRun => {
-  const logger = console.error
-  console.error = () => {}
+  const logger = console.error;
+  console.error = () => {};
 
-  codeToRun()
+  codeToRun();
 
-  console.error = logger
-}
+  console.error = logger;
+};
 
-test('Router throws when no createHistory is provided, or its not a function', () => {
+test("Router throws when no createHistory is provided, or its not a function", () => {
   pauseErrorLogging(() =>
     expect(() => {
-      render(<Router />)
+      render(<Router />);
     }).toThrowErrorMatchingInlineSnapshot(
-      `"createHistory prop was either not provided, or is not a function."`,
-    ),
-  )
+      `"createHistory prop was either not provided, or is not a function."`
+    )
+  );
 
   pauseErrorLogging(() =>
     expect(() => {
-      render(<Router createHistory={null} />)
+      render(<Router createHistory={null} />);
     }).toThrowErrorMatchingInlineSnapshot(
-      `"createHistory prop was either not provided, or is not a function."`,
-    ),
-  )
-})
+      `"createHistory prop was either not provided, or is not a function."`
+    )
+  );
+});
+
+test("useLink`s linkClick callback throws when no history is provided within context", () => {
+  let clickHandler;
+  function Link() {
+    let getLinkProps = useLink("/foo");
+    let { onClick, ...rest } = getLinkProps();
+    clickHandler = onClick;
+    return null;
+  }
+  render(<Link />);
+
+  expect(() => clickHandler({ defaultPrevented: false, preventDefault() {} }))
+    .toThrowErrorMatchingInlineSnapshot(`
+"Link attempted to route to path: '/foo' but no history was found in context.
+
+Check to ensure the link is rendered within a Router."
+`);
+});

--- a/core/src/mod.js
+++ b/core/src/mod.js
@@ -53,6 +53,11 @@ export function useLink(path, state) {
         return
       }
       event.preventDefault()
+      if (history === null || history === undefined) {
+        throw new Error(`Link attempted to route to path: '${path}' but no history was found in context.
+
+Check to ensure the link is rendered within a Router.`)
+      }
       history.push(path, state)
     },
     [history],

--- a/core/src/mod.js
+++ b/core/src/mod.js
@@ -1,6 +1,14 @@
 import React from 'react'
 
-const { createContext, useContext, useState, useMemo, useLayoutEffect, useRef, useCallback } = React
+const {
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+  useLayoutEffect,
+  useRef,
+  useCallback,
+} = React
 
 let historyContext = createContext({
   history: null,
@@ -11,7 +19,9 @@ let historyContext = createContext({
 
 export function Router({ children, createHistory }) {
   if (typeof createHistory !== 'function') {
-    throw new Error('createHistory prop was either not provided, or is not a function.')
+    throw new Error(
+      'createHistory prop was either not provided, or is not a function.',
+    )
   }
   let { current: history } = useLazyRef(createHistory)
   let [location, setLocation] = useState(history.location)
@@ -38,7 +48,11 @@ export function Router({ children, createHistory }) {
     [location],
   )
 
-  return <historyContext.Provider value={contextValue}>{children}</historyContext.Provider>
+  return (
+    <historyContext.Provider value={contextValue}>
+      {children}
+    </historyContext.Provider>
+  )
 }
 
 export function useHistory() {


### PR DESCRIPTION
Noticing this error happening within the Cash app, I think this is due to a missing history in context for the link. 

Opting to throw here instead of silently letting the link do a full page refresh.